### PR TITLE
Handbook improvements

### DIFF
--- a/docs/handbook.md
+++ b/docs/handbook.md
@@ -191,6 +191,8 @@ The University has its own [security service](https://www.security.admin.cam.ac.
 
 ## Renting in the University's key worker accommodation
 
+To qualify for [University Accommodation](https://www.accommodation.cam.ac.uk/FindAHome/), applicants must be a student or member of staff employed by the University of Cambridge, a Cambridge College or one of the Affiliated Institutions.
+
 ## Freehold and leasehold privately owned properties
 
 ## Councils and democratic representation

--- a/docs/handbook.md
+++ b/docs/handbook.md
@@ -6,6 +6,9 @@ redirect_from:
   - /faq
 ---
 
+* Table of Contents
+{:toc}
+
 <i>
 A guide for residents of Eddington to the many places, processes, practices and policies that are uniquely relevant to this development. This remains a work-in-progress - please [contribute any corrections]({{ site.github.repository_url }}/tree/main/docs/{{ page.path }}){:target="_blank"}.
 </i>


### PR DESCRIPTION
### Changes
- Adds a link to the University's Accomodation Service website.
- Adds a table of contents to the handbook

### Screenshot of handbook TOC
![image](https://github.com/Eddington-Residents-Association/website/assets/721919/81c989d7-d208-45bc-8a44-706555820df3)
