### PR TITLE
Events page improvements

### DIFF
--- a/docs/events.md
+++ b/docs/events.md
@@ -136,14 +136,20 @@ function makeEventsPageHtml(events, start_date){
           +`<br><br>\n\n`
       ).join("\n")
 
-    html += `<tr class="day ${weekend_class}">
+
+    prev_date = date;
+
+    if (events_html === "") {
+      continue;
+    }
+
+    html += `<tr class="day">
     <td class="date"><a href="#${date_name}" name="${date_name}">${date_str}</a></td>
     <td class="events">
       ${events_html}
     </td>
 </tr>\n`
 
-    prev_date = date;
   }
   html += `  </tbody>\n</table>`
 


### PR DESCRIPTION
- Don't show dates without events in events page
- Remove styling for weekends

## 1080p Desktop - Before

### Initial load
![Screen Shot 2024-04-07 at 17 15 57](https://github.com/Eddington-Residents-Association/website/assets/721919/f1a60414-70e7-449f-8678-2bfd12d6106d)

### After scroll event is triggered
![Screen Shot 2024-04-07 at 17 48 54](https://github.com/Eddington-Residents-Association/website/assets/721919/ed0552f1-ad8f-4218-8ffc-58d3d8d940e3)

## 1080p Desktop - After

### Initial load

![Screen Shot 2024-04-07 at 17 40 23](https://github.com/Eddington-Residents-Association/website/assets/721919/6bd9ff9a-c231-4eb8-9651-0a6d7538919d)


### After scroll event is triggered

![Screen Shot 2024-04-07 at 17 40 47](https://github.com/Eddington-Residents-Association/website/assets/721919/7f0da058-ad2e-4032-bbfa-635ec1493d22)

## Mobile - Before

### Initial load
![Screen Shot 2024-04-07 at 17 15 47](https://github.com/Eddington-Residents-Association/website/assets/721919/c145c474-6111-49c9-84ba-f9d307cfa46e)


## Mobile - After

### Initial load
![Screen Shot 2024-04-07 at 17 51 45](https://github.com/Eddington-Residents-Association/website/assets/721919/b563ebae-5467-4fc3-8797-b081a01490c6)
